### PR TITLE
Quick start documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![devDependencies Status](https://david-dm.org/HydeInit/Mixer-Desktop/dev-status.svg)](https://david-dm.org/HydeInit/Mixer-Desktop?type=dev)
 [![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/HydeInit/Developers)
 
-:memo: Available Translations: coming soon 
+:memo: Available Translations: coming soon
 
-The [Electron](https://github.com/electron) framework aloud us to write a cross-platform desktop application for 
+The [Electron](https://github.com/electron) framework aloud us to write a cross-platform desktop application for
 [Mixer](https://github.com/mixer)
 using [NodeJS](https://github.com/nodejs).
 
-This project adheres to the Contributor Covenant 
+This project adheres to the Contributor Covenant
 [code of conduct](https://github.com/HydeInit/Mixer-Desktop/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable
 behavior to [support@hydeinit.com](mailto:support@hydeinit.com).
@@ -25,6 +25,8 @@ cd Mixer-Desktop
 npm install
 npm start
 ```
+> Note: you can also run `electron .` instead of `npm start`
+
 ## Help wanted!
 
 We are looking for developers to help develop this project to present to the official team at mixer. Please submit some ideas in the issues section or some PRs to get this project going. If you are interested, you can become a collaborator on the project. Thanks.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Mixer Desktop Client",
   "main": "main.js",
   "scripts": {
-    "test": "electron .",
+    "start": "electron . ",
+    "test": "",
     "package-mac": "electron-packager . --overwrite --asar=true --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
     "package-win": "electron-packager . --overwrite --platform=win32 --arch=ia32 --icon=icons/win/icon.ico --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"Mixer Desktop\"",
     "package-linux": "electron-packager . --overwrite --asar=true --platform=linux --arch=x64 --icon=assets/icons/png/1024x1024.png --prune=true --out=release-builds",


### PR DESCRIPTION
## Regarding issue #6  
* changed the documentation to show that you can run `electron .` as well
* changed `npm start` script to run `electron .` - running the application previously did not work on *nix and windows.